### PR TITLE
Changing ts-node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Backend for Hyper Protect SDK for iOS",
   "devDependencies": {
     "@types/node": "^8.10.60",
-    "ts-node": "^3.3.0",
+    "ts-node": "^8.8.0",
     "typescript": "^2.9.2"
   },
   "dependencies": {


### PR DESCRIPTION
Modifying 'ts-node' version to "^8.8.0". Any ts-node version greater than 8.8.0 compiles without errors. 