### PR TITLE
Adding the dotenv package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "class-validator": "^0.12.2",
     "config": "^3.3.1",
     "cors": "^2.8.5",
+    "dotenv": "^8.1",
     "errorhandler": "^1.5.1",
     "express": "^4.15.4",
     "helmet": "^3.22.0",


### PR DESCRIPTION
Modifying 'ts-node' version to "^8.8.0". Any ts-node version greater than 8.8.0 compiles without errors. 

Also needed to add the dotenv package, as that is what I'm using in index.ts to read the environmental variables containing the MongoDB information written by the lab participants. 