### PR TITLE
Update generate_certs.sh

### DIFF
--- a/generate_certs.sh
+++ b/generate_certs.sh
@@ -27,13 +27,14 @@ generateCerts() {
   openssl genrsa -out $PWD/carekit-sdk.key 2048
   openssl req -new -sha256 -key $PWD/carekit-sdk.key -subj "/C=US/ST=NC/O=IBM/CN=$CN" -out $PWD/carekit-sdk.csr
   openssl x509 -req -in $PWD/carekit-sdk.csr -CA $PWD/carekit-root.crt -CAkey $PWD/carekit-root.key -CAcreateserial -out $PWD/carekit-sdk.crt -days 500 -sha256
+
   # Logic to copy keys over if script is run on HPVS
   if [ $REPO ]
   then
-    cp carekit* $PWD/$REPO/
+    cp carekit* $PWD/$REPO/src/
+  else
+    mv carekit* $PWD/src/
   fi
-  # moving certificates to src directory for app
-  mv carekit* $PWD/src/
 }
 
 ####################

--- a/generate_certs.sh
+++ b/generate_certs.sh
@@ -2,19 +2,62 @@
 #
 # Generates SSL certificates for CareKit
 
-main() {
-# Create keys and certs
+helpFunction() {      # help function with arg / run instructions
+  echo "Usage: "
+  echo "$0 -c <CommonName>"
+  echo ""
+  echo "OR"
+  echo "$0 -c <CommonName> -r <RepoName>"
+  echo ""
+  echo "The 2nd parameter '-r' is only required during an HPVS bootstrap"
+  echo "Example of -r: IBM-HyperProtectMBaaS"
+  echo ""
+  echo "For configuring the BackendSDK locally, use -c localhost. "
+  echo "If bootstrapping an HPVS instance, use -c <Public IP for HPVS>"
+  echo ""
+  echo "Note: You may have to run generate_certs.sh with 'sudo'"
+  echo ""
+  exit 1
+}
+
+generateCerts() {
+  # Create keys and certs
   openssl genrsa -out $PWD/carekit-root.key 4096
-  openssl req -x509 -new -nodes -key $PWD/carekit-root.key -sha256 -days 1024 -out $PWD/carekit-root.crt -subj "/C=US/ST=NC/O=IBM/OU=ZaaS/CN=$1"
+  openssl req -x509 -new -nodes -key $PWD/carekit-root.key -sha256 -days 1024 -out $PWD/carekit-root.crt -subj "/C=US/ST=NC/O=IBM/OU=ZaaS/CN=$CN"
   openssl genrsa -out $PWD/carekit-sdk.key 2048
-  openssl req -new -sha256 -key $PWD/carekit-sdk.key -subj "/C=US/ST=NC/O=IBM/CN=$1" -out $PWD/carekit-sdk.csr
+  openssl req -new -sha256 -key $PWD/carekit-sdk.key -subj "/C=US/ST=NC/O=IBM/CN=$CN" -out $PWD/carekit-sdk.csr
   openssl x509 -req -in $PWD/carekit-sdk.csr -CA $PWD/carekit-root.crt -CAkey $PWD/carekit-root.key -CAcreateserial -out $PWD/carekit-sdk.crt -days 500 -sha256
-
-# Comment the below cp command if this is a local setup!
-  cp carekit* $PWD/$2/src/
-
-# moving certificates to src directory for app
+  # Logic to copy keys over if script is run on HPVS
+  if [ $REPO ]
+  then
+    cp carekit* $PWD/$REPO/
+  fi
+  # moving certificates to src directory for app
   mv carekit* $PWD/src/
 }
 
-main $1 $2
+####################
+# main code block
+####################
+while getopts "c:r:" opt
+do
+   case "$opt" in
+      c ) CN="$OPTARG" ;;
+      r ) REPO="$OPTARG" ;;
+      ? ) helpFunction ;; # Print helpFunction in case parameter is non-existent
+   esac
+done
+
+if [ -z "$CN" ]
+then
+   echo "1 mandatory argument is required: -c {CommonName}";
+   helpFunction
+fi
+
+# Generate certificates based on parameters and arguments provided
+if [[ $REPO ]]; then
+  generateCerts $CN $REPO
+else
+  generateCerts $CN
+fi
+


### PR DESCRIPTION
Added logic to bash script. The logic implemented handles whether a Git repo name was provided or not, as the repo name is required while running the script on an HPVS instance, but not while running for localhost.