### PR TITLE
Create EnableEntity.ts

### DIFF
--- a/src/controllers/EnableEntity.ts
+++ b/src/controllers/EnableEntity.ts
@@ -1,0 +1,71 @@
+/*
+ Copyright (c) 2020, International Business Machines All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+ import { getRepository, getMongoRepository } from "typeorm";
+ import { OCKTask } from "../entity/OCKTask";
+ import { OCKOutcome } from "../entity/OCKOutcome";
+ import * as util from "util";
+ import {
+   createOrIncrementClock,
+   getLatestKnowledgeVector,
+   isOutcomeNew,
+   deleteExistingOutcomeForUpdate,
+   uuid,
+   mergeKnowledgeVectors,
+ } from "../utils";
+ import { KnowledgeVector, Process } from "../entity/KnowledgeVector";
+ import assert from "assert";
+ import { isEmpty, isNotEmpty, isUUID, validate } from "class-validator";
+
+let entity;
+let repository;
+
+export async function processEntity(...entityParams) {
+   if (entityParams) {
+     entity = entityParams[0];
+     repository = entityParams[1];
+   } else {
+     console.log("Incorrect number of params sent from RevisionRecord to EnableEntity");
+   }
+   try {
+     const entityExists = await repository.findOne({ uuid: entity.object.uuid });
+     // if entity exists, don't overwrite
+     if (isEmpty(entityExists)) {
+       const task = repository.create(entity.object);
+       task.kv = await getLatestKnowledgeVector();
+       console.log(util.inspect(task, false, null, true /* enable colors */));
+       await repository.save(task);
+       //await createOrIncrementClock();
+     }
+   } catch (e) {
+     res.status(409).send("Entity exists");
+     return;
+   }
+}


### PR DESCRIPTION
`EnableEntity.ts` is a new file that contains function named processEntity that `RevisionRecordController.ts` passes entity related data to. This function will process the entities, as the code within the function is utilized by every entity (outcomes, tasks, patients, contacts, careplans) and does not need to be duplicated under each case within the `RevisionRecordController.ts` switch statement. The _params_ feature of typescript was used in the processEntity function, and accepts two arguments. The entities that are iterated over by a for loop, and the {entity}Repository which is a constant. If the record or entity exists already, a 409 response is sent, which works the same as the previous setup when just outcomes and tasks were enabled.